### PR TITLE
Fix order dependent tests in CloudFoundryMvcWebEndpointIntegrationTests

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.actuate.autoconfigure.cloudfoundry.AccessLevel;
@@ -62,6 +63,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 
 /**
  * Integration tests for web endpoints exposed using Spring MVC on CloudFoundry.
@@ -73,6 +75,11 @@ class CloudFoundryMvcWebEndpointIntegrationTests {
 	private static final TokenValidator tokenValidator = mock(TokenValidator.class);
 
 	private static final CloudFoundrySecurityService securityService = mock(CloudFoundrySecurityService.class);
+
+	@AfterEach
+	void tearDown() {
+		reset(tokenValidator);
+	}
 
 	@Test
 	void operationWithSecurityInterceptorForbidden() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

#### Issue
- The following tests in `org.springframework.boot.actuate.autoconfigure.cloudfoundry.servlet.CloudFoundryMvcWebEndpointIntegrationTests` may fail if run by their own, or more generally, when run at any time after running the test `linksToOtherEndpointsForbidden()`
  - `operationWithSecurityInterceptorForbidden()`
  - `operationWithSecurityInterceptorSuccess()`
  - `linksToOtherEndpointsWithFullAccess()`
  - `linksToOtherEndpointsWithRestrictedAccess()`
- When the above mentioned tests are run after the test `linksToOtherEndpointsForbidden()`, we get the following error
```
java.lang.AssertionError: Status expected:<403 FORBIDDEN> but was:<401 UNAUTHORIZED>
	at org.springframework.test.util.AssertionErrors.fail(AssertionErrors.java:59)
	at org.springframework.test.util.AssertionErrors.assertEquals(AssertionErrors.java:122)
	at org.springframework.test.web.reactive.server.StatusAssertions.lambda$isEqualTo$0(StatusAssertions.java:53)
	at org.springframework.test.web.reactive.server.ExchangeResult.assertWithDiagnostics(ExchangeResult.java:222)
	at org.springframework.test.web.reactive.server.StatusAssertions.isEqualTo(StatusAssertions.java:53)
	at org.springframework.boot.actuate.autoconfigure.cloudfoundry.servlet.CloudFoundryMvcWebEndpointIntegrationTests.lambda$operationWithSecurityInterceptorForbidden$0(CloudFoundryMvcWebEndpointIntegrationTests.java:92)
	at org.springframework.boot.actuate.autoconfigure.cloudfoundry.servlet.CloudFoundryMvcWebEndpointIntegrationTests.lambda$load$2(CloudFoundryMvcWebEndpointIntegrationTests.java:216)
	at org.springframework.boot.actuate.autoconfigure.cloudfoundry.servlet.CloudFoundryMvcWebEndpointIntegrationTests.load(CloudFoundryMvcWebEndpointIntegrationTests.java:219)
	at org.springframework.boot.actuate.autoconfigure.cloudfoundry.servlet.CloudFoundryMvcWebEndpointIntegrationTests.operationWithSecurityInterceptorForbidden(CloudFoundryMvcWebEndpointIntegrationTests.java:85)
```
- This makes the above mentioned tests to be order dependent

#### Reason
- In the test `CloudFoundryMvcWebEndpointIntegrationTests.linksToOtherEndpointsForbidden()`, the `TokenValidator tokenValidator` mock is set to throw `CloudFoundryAuthorizationException` when `tokenValidator.validate(any())` is called. However, this is not reset after the unit test is run.
https://github.com/spring-projects/spring-boot/blob/da67ce4a76091398ad336b49f4964a1b210568bb/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java#L158-L160
- All the above mentioned tests loads the `ApplicationContext` at https://github.com/spring-projects/spring-boot/blob/da67ce4a76091398ad336b49f4964a1b210568bb/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java#L211-L212
- This `CloudFoundryMvcConfiguration` uses the same polluted `tokenValidator` mock to load the `org.springframework.boot.actuate.autoconfigure.cloudfoundry.servlet.CloudFoundrySecurityInterceptor` for preHandling at https://github.com/spring-projects/spring-boot/blob/da67ce4a76091398ad336b49f4964a1b210568bb/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundryMvcWebEndpointIntegrationTests.java#L233
- The preHandling calls the polluted `tokenValidator.validate(any())` at https://github.com/spring-projects/spring-boot/blob/da67ce4a76091398ad336b49f4964a1b210568bb/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/servlet/CloudFoundrySecurityInterceptor.java#L91
- So, when the above mentioned tests are called after `linksToOtherEndpointsForbidden()` without resetting the `tokenValidator` mock, the mock throws `CloudFoundryAuthorizationException`.
- Since `CloudFoundryAuthorizationException` is created with the reason `Reason.INVALID_TOKEN` and this reason is associated with `HttpStatus.UNAUTHORIZED`, we get the above `AssertionFailedError: Status expected:<403 FORBIDDEN> but was:<401 UNAUTHORIZED>`
https://github.com/spring-projects/spring-boot/blob/da67ce4a76091398ad336b49f4964a1b210568bb/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/cloudfoundry/CloudFoundryAuthorizationException.java#L89

#### Steps to Reproduce
- Run the above mentioned tests after running `CloudFoundryWebFluxEndpointIntegrationTests.linksToOtherEndpointsForbidden()`

#### Proposed Fix
- Since using the same polluted state of the `tokenValidator` mock causes this issue, resetting the mock's state after each test run will resolve this issue.
- Added a `tearDown()` method with `@AfterEach` where the `tokenValidator` state is reset using `Mockito.reset()`